### PR TITLE
AWS Manually Run Task Error

### DIFF
--- a/lib/classes/task/manager.php
+++ b/lib/classes/task/manager.php
@@ -1412,7 +1412,7 @@ class manager {
             2 => ['pipe', 'w'], // STDERR.
         ];
         flush();
-        $process = proc_open($command, $descriptorspec, $pipes, realpath('./'), []);
+        $process = proc_open($command, $descriptorspec, $pipes, realpath('./'));
         if (is_resource($process)) {
             while ($s = fgets($pipes[1])) {
                 mtrace($s, '');


### PR DESCRIPTION
Remove environment variable override to persist AWS variables.
Resolves fatal error encountered when manually running scheduled tasks.