### PR TITLE
Persistent Form Allow Null Values

### DIFF
--- a/lib/classes/form/persistent.php
+++ b/lib/classes/form/persistent.php
@@ -228,7 +228,14 @@ abstract class persistent extends moodleform {
 
         foreach ($data as $field => $value) {
             // Clean data if it is to be displayed in a form.
-            if (isset($allproperties[$field]['type'])) {
+            if (
+                isset($allproperties[$field]['type']) &&
+                // GCH NL: Don't clean null values where null is allowed to avoid casting. e.g. null -> zero.
+                (
+                    $data->$field !== null ||
+                    $allproperties[$field]['null'] === NULL_NOT_ALLOWED
+                )
+            ) {
                 $data->$field = clean_param($data->$field, $allproperties[$field]['type']);
             }
 


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
Don't clean null values in `\core\form\persistent:get_default_data()` when null is allowed.
This resolves form display / data issues where nullable fields are cast in `clean_param()` e.g. null int field is cast to zero which when used with an 'autocomplete' field results in a single selected option with a value and label of '0' being displayed in the form.

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Code has been commented, particularly in hard-to-understand areas.
