### PR TITLE
GS-1234 SCORM Query Poor Performance

### DIFF
--- a/mod/scorm/lib.php
+++ b/mod/scorm/lib.php
@@ -1331,27 +1331,85 @@ function scorm_check_mode($scorm, &$newattempt, &$attempt, $userid, &$mode) {
     }
     $completionelement = $completionelements[$scormversion];
 
-    $sql = "SELECT sc.id, sub.value
-              FROM {scorm_scoes} sc
-         LEFT JOIN (SELECT v.scoid, v.value
-                      FROM {scorm_attempt} a
-                      JOIN {scorm_scoes_value} v ON a.id = v.attemptid
-                      JOIN {scorm_element} e on e.id = v.elementid AND e.element = :element
-                     WHERE a.userid = :userid AND a.attempt = :attempt AND a.scormid = :scormid) sub ON sub.scoid = sc.id
-             WHERE sc.scormtype = 'sco' AND sc.scorm = :scormid2";
-    $tracks = $DB->get_recordset_sql($sql, ['userid' => $userid, 'attempt' => $attempt,
-                                            'element' => $completionelement, 'scormid' => $scorm->id,
-                                            'scormid2' => $scorm->id]);
+    $scoeids = $DB->get_fieldset(
+        'scorm_scores',
+        'id',
+        [
+            'scormtype' => 'sco',
+            'scorm' => $scorm->id
+        ]
+    );
 
-    foreach ($tracks as $track) {
-        if (($track->value == 'completed') || ($track->value == 'passed') || ($track->value == 'failed')) {
+    if (!empty($scoeids)) {
+        [ $scoessql, $scoesparams ] = $DB->get_in_or_equal($scoeids, SQL_PARAMS_NAMED);
+
+        $sql = "
+            SELECT  v.scoid,
+                    v.value
+            FROM    {scorm_scoes_value} v
+                    JOIN {scorm_element} e ON
+                        e.id = v.elementid
+                    JOIN {scorm_attempt} a ON
+                        a.id = v.attemptid
+            WHERE   v.scoid $scoessql
+                    e.element = :element AND
+                    a.userid = :userid AND
+                    a.attempt = :attempt AND
+                    a.scormid = :scormid
+        ";
+
+        $scoevalues = $DB->get_records_sql_menu(
+            $sql,
+            array_merge(
+                $scoesparams,
+                [
+                    'element' => $completionelement,
+                    'userid' => $userid,
+                    'attempt' => $attempt,
+                    'scormid' => $scorm->id,
+                ]
+            )
+        );
+
+        foreach ($scoeids as $scoeid) {
+            $value = $scoevalues[$scoeid] ?? null;
+            if (
+                $value === null ||
+                !in_array(
+                    $value,
+                    ['completed', 'passed', 'failed']
+                )
+            ) {
+                $incomplete = true;
+
+                break;
+            }
+
             $incomplete = false;
-        } else {
-            $incomplete = true;
-            break; // Found an incomplete sco, so the result as a whole is incomplete.
         }
+
+        //$sql = "SELECT sc.id, sub.value
+        //      FROM {scorm_scoes} sc
+        // LEFT JOIN (SELECT v.scoid, v.value
+        //              FROM {scorm_attempt} a
+        //              JOIN {scorm_scoes_value} v ON a.id = v.attemptid
+        //              JOIN {scorm_element} e on e.id = v.elementid AND e.element = :element
+        //             WHERE a.userid = :userid AND a.attempt = :attempt AND a.scormid = :scormid) sub ON sub.scoid = sc.id
+        //     WHERE sc.scormtype = 'sco' AND sc.scorm = :scormid2";
+        //$tracks = $DB->get_recordset_sql($sql, [ 'userid' => $userid, 'attempt' => $attempt,
+        //    'element' => $completionelement, 'scormid' => $scorm->id,
+        //    'scormid2' => $scorm->id ]);
+        //
+        //foreach ($tracks as $track) {
+        //    if (($track->value == 'completed') || ($track->value == 'passed') || ($track->value == 'failed')) {
+        //        $incomplete = false;
+        //    } else {
+        //        $incomplete = true;
+        //        break; // Found an incomplete sco, so the result as a whole is incomplete.
+        //    }
+        //}
+        //$tracks->close();
     }
-    $tracks->close();
 
     // Validate user request to start a new attempt.
     if ($incomplete === true) {

--- a/mod/scorm/lib.php
+++ b/mod/scorm/lib.php
@@ -1332,7 +1332,7 @@ function scorm_check_mode($scorm, &$newattempt, &$attempt, $userid, &$mode) {
     $completionelement = $completionelements[$scormversion];
 
     $scoeids = $DB->get_fieldset(
-        'scorm_scores',
+        'scorm_scoes',
         'id',
         [
             'scormtype' => 'sco',
@@ -1351,7 +1351,7 @@ function scorm_check_mode($scorm, &$newattempt, &$attempt, $userid, &$mode) {
                         e.id = v.elementid
                     JOIN {scorm_attempt} a ON
                         a.id = v.attemptid
-            WHERE   v.scoid $scoessql
+            WHERE   v.scoid $scoessql AND
                     e.element = :element AND
                     a.userid = :userid AND
                     a.attempt = :attempt AND

--- a/mod/scorm/lib.php
+++ b/mod/scorm/lib.php
@@ -1387,28 +1387,6 @@ function scorm_check_mode($scorm, &$newattempt, &$attempt, $userid, &$mode) {
 
             $incomplete = false;
         }
-
-        //$sql = "SELECT sc.id, sub.value
-        //      FROM {scorm_scoes} sc
-        // LEFT JOIN (SELECT v.scoid, v.value
-        //              FROM {scorm_attempt} a
-        //              JOIN {scorm_scoes_value} v ON a.id = v.attemptid
-        //              JOIN {scorm_element} e on e.id = v.elementid AND e.element = :element
-        //             WHERE a.userid = :userid AND a.attempt = :attempt AND a.scormid = :scormid) sub ON sub.scoid = sc.id
-        //     WHERE sc.scormtype = 'sco' AND sc.scorm = :scormid2";
-        //$tracks = $DB->get_recordset_sql($sql, [ 'userid' => $userid, 'attempt' => $attempt,
-        //    'element' => $completionelement, 'scormid' => $scorm->id,
-        //    'scormid2' => $scorm->id ]);
-        //
-        //foreach ($tracks as $track) {
-        //    if (($track->value == 'completed') || ($track->value == 'passed') || ($track->value == 'failed')) {
-        //        $incomplete = false;
-        //    } else {
-        //        $incomplete = true;
-        //        break; // Found an incomplete sco, so the result as a whole is incomplete.
-        //    }
-        //}
-        //$tracks->close();
     }
 
     // Validate user request to start a new attempt.


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
Splits the SCORM status lookup single query with a poorly performing left join sub-query into two distinct queries.
This provides a significant performance uplift as each query takes a fraction of a second to execute vs the single query taking upwards of a minute in some cases.

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Code has been commented, particularly in hard-to-understand areas.
