### PR TITLE
GS-1279 Add pre-update archive hook in core Moodle

### DIFF
--- a/lib/completionlib.php
+++ b/lib/completionlib.php
@@ -28,6 +28,7 @@
 
 use core_completion\activity_custom_completion;
 use core_courseformat\base as course_format;
+
 defined('MOODLE_INTERNAL') || die();
 
 /**

--- a/lib/completionlib.php
+++ b/lib/completionlib.php
@@ -28,8 +28,6 @@
 
 use core_completion\activity_custom_completion;
 use core_courseformat\base as course_format;
-use local_lolcompletion\local\api\completion;
-
 defined('MOODLE_INTERNAL') || die();
 
 /**
@@ -613,6 +611,8 @@ class completion_info {
             }
         }
 
+        // GCHLOL - Archive the current state of this activity for user. Do this before updating the state.
+        \local_lolcompletion\local\api\completion::archive_before_state_update($this->course_id, $cm->id, $userid, $possibleresult, $current->completionstate);
         // Get current value of completion state and do nothing if it's same as
         // the possible result of this change. If the change is to COMPLETE and the
         // current value is one of the COMPLETE_xx subtypes, ignore that as well
@@ -656,7 +656,6 @@ class completion_info {
 
         // If the overall completion state has changed, update it in the cache.
         if ($newstate != $current->completionstate) {
-            completion::archive_before_state_update($this->course_id, $cm->id, $userid, $newstate, $current->completionstate);
             $current->completionstate = $newstate;
             $current->timemodified    = time();
             $current->overrideby      = $override ? $USER->id : null;

--- a/lib/completionlib.php
+++ b/lib/completionlib.php
@@ -28,6 +28,7 @@
 
 use core_completion\activity_custom_completion;
 use core_courseformat\base as course_format;
+use local_lolcompletion\local\api\completion;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -655,6 +656,7 @@ class completion_info {
 
         // If the overall completion state has changed, update it in the cache.
         if ($newstate != $current->completionstate) {
+            completion::archive_before_state_update($this->course_id, $cm->id, $userid, $newstate, $current->completionstate);
             $current->completionstate = $newstate;
             $current->timemodified    = time();
             $current->overrideby      = $override ? $USER->id : null;


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
This PR archives the previous activity completion state before `course_modules_completion.completionstate` is updated in `completion_info::update_state()`.

## What changed
- Updated `lib/completionlib.php`.
- Added a call to:
  `local_lolcompletion\local\api\completion::archive_before_state_update($courseid, $cmid, $userid, $newstate, $oldstate)`
- The call runs only when the computed completion state actually changes.

## Impact / risk
- Introduces a dependency on `local_lolcompletion` API from core completion flow.
- Expected behavior is unchanged for completion updates, with archiving added before persistence.

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).

