### PR TITLE
GS-1279-Add-pre-update-archive-hook-in-core-Moodle-fix

### DIFF
--- a/lib/completionlib.php
+++ b/lib/completionlib.php
@@ -612,8 +612,8 @@ class completion_info {
             }
         }
 
-        // GCHLOL - Archive the current state of this activity for user. Do this before updating the state.
-        \local_lolcompletion\local\api\completion::archive_before_state_update($this->course_id, $cm->id, $userid, $possibleresult, $current->completionstate);
+        // GCHLOL - Archive the current state of this activity for user. The API resolves the current state.
+        \local_lolcompletion\local\api\completion::archive_before_state_update($this->course_id, $cm->id, $userid, $possibleresult);
         // Get current value of completion state and do nothing if it's same as
         // the possible result of this change. If the change is to COMPLETE and the
         // current value is one of the COMPLETE_xx subtypes, ignore that as well


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->

Remove `$current->completionstate` from the
`archive_before_state_update()` call in `completion_info::update_state()`.

The archive API now performs its own DB lookup for the existing
completion state, which also avoids referencing `$current` before it is
initialised.

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
